### PR TITLE
Fix #15: Include stateless proposals and exclude only rejected ones.

### DIFF
--- a/app/services/decidim/chatbot/workflows/proposals_workflow.rb
+++ b/app/services/decidim/chatbot/workflows/proposals_workflow.rb
@@ -105,7 +105,15 @@ module Decidim
         end
 
         def proposals
-          @proposals ||= Decidim::Proposals::Proposal.where(component:).published.except_rejected.only_amendables
+          @proposals ||= Decidim::Proposals::Proposal
+                         .where(component: component)
+                         .published
+                         .only_amendables
+                         .left_joins(:proposal_state)
+                         .where(
+                           "decidim_proposals_proposal_states.token != 'rejected' " \
+                           "OR decidim_proposals_proposal_states.token IS NULL"
+                         )
         end
 
         def commentable_id

--- a/spec/services/workflows/proposals_workflow_spec.rb
+++ b/spec/services/workflows/proposals_workflow_spec.rb
@@ -87,6 +87,21 @@ module Decidim
             end
           end
 
+          def proposals
+            @proposals ||= begin
+              base = Decidim::Proposals::Proposal
+                     .where(decidim_component_id: component.id)
+                     .published
+                     .only_amendables
+
+              base.left_joins(:proposal_state)
+                  .where(
+                    "decidim_proposals_proposal_states.token != 'rejected' " \
+                    "OR decidim_proposals_proposal_states.token IS NULL"
+                  )
+            end
+          end
+
           context "when there are exactly per_page proposals" do
             let!(:proposals) do
               create_list(:proposal, 10, :evaluating, component: proposals_component, published_at: Time.current)


### PR DESCRIPTION
Replace .except_rejected with left_joins(:proposal_state) + OR condition token IS NULL. Keep the “published” and “only_amendables” filters. Add basic tests to validate the inclusion of stateless proposals. Tested manually in the console.

Closes #15