### PR TITLE
Extract video URLs and thumbnails from proposal iframes

### DIFF
--- a/app/services/decidim/chatbot/media/video_embed_extractor.rb
+++ b/app/services/decidim/chatbot/media/video_embed_extractor.rb
@@ -7,7 +7,7 @@ module Decidim
       # Supports YouTube and Vimeo embeds
       class VideoEmbedExtractor
         # Regex patterns to match iframe src attributes for supported video platforms
-        YOUTUBE_PATTERN = %r{<iframe[^>]+src=["\']https?://(?:www\.)?(?:youtube\.com/embed/|youtu\.be|youtube-nocookie\.com/embed/)([a-zA-Z0-9_-]+)(?:[?&][^"\']*)?["\'][^>]*>}i
+        YOUTUBE_PATTERN = %r{<iframe[^>]+src=["\']https?://(?:www\.)?(?:youtube\.com/embed/|youtu\.be/|youtube-nocookie\.com/embed/)([a-zA-Z0-9_-]+)(?:[?&][^"\']*)?["\'][^>]*>}i
         VIMEO_PATTERN = %r{<iframe[^>]+src=["\']https?://(?:www\.)?player\.vimeo\.com/video/(\d+)(?:[?&][^"\']*)?["\'][^>]*>}i
 
         # Extracts a video URL from HTML content

--- a/app/services/decidim/chatbot/media/video_embed_extractor.rb
+++ b/app/services/decidim/chatbot/media/video_embed_extractor.rb
@@ -75,9 +75,10 @@ module Decidim
         end
 
         # Returns YouTube thumbnail URL
-        # Uses maxresdefault for best quality, falls back to hqdefault
         def youtube_thumbnail_url
-          "https://img.youtube.com/vi/#{video_id}/maxresdefault.jpg"
+          # hqdefault (480×360) is guaranteed to exist for every published video.
+          # maxresdefault (1280×720) is only generated for HD uploads and 404s otherwise.
+          "https://img.youtube.com/vi/#{video_id}/hqdefault.jpg"
         end
 
         # Returns Vimeo thumbnail URL using oEmbed API pattern

--- a/app/services/decidim/chatbot/media/video_embed_extractor.rb
+++ b/app/services/decidim/chatbot/media/video_embed_extractor.rb
@@ -10,9 +10,8 @@ module Decidim
         YOUTUBE_PATTERN = %r{<iframe[^>]+src=["\']https?://(?:www\.)?(?:youtube\.com/embed/|youtu\.be/|youtube-nocookie\.com/embed/)([a-zA-Z0-9_-]+)(?:[?&][^"\']*)?["\'][^>]*>}i
         VIMEO_PATTERN = %r{<iframe[^>]+src=["\']https?://(?:www\.)?player\.vimeo\.com/video/(\d+)(?:[?&][^"\']*)?["\'][^>]*>}i
 
-        # Extracts a video URL from HTML content
-        # @param html [String] The HTML string to parse
-        # @return [Hash] A hash with :video_url key containing the extracted URL or nil
+        # Initializes a new extractor with the given HTML content
+        # @param html [String] The HTML string to parse for embedded videos
         def initialize(html)
           @html = html
         end

--- a/app/services/decidim/chatbot/media/video_embed_extractor.rb
+++ b/app/services/decidim/chatbot/media/video_embed_extractor.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Chatbot
+    module Media
+      # Service class to extract video URLs from HTML iframes
+      # Supports YouTube and Vimeo embeds
+      class VideoEmbedExtractor
+        # Regex patterns to match iframe src attributes for supported video platforms
+        YOUTUBE_PATTERN = %r{<iframe[^>]+src=["\']https?://(?:www\.)?(?:youtube\.com/embed/|youtu\.be|youtube-nocookie\.com/embed/)([a-zA-Z0-9_-]+)(?:[?&][^"\']*)?["\'][^>]*>}i
+        VIMEO_PATTERN = %r{<iframe[^>]+src=["\']https?://(?:www\.)?player\.vimeo\.com/video/(\d+)(?:[?&][^"\']*)?["\'][^>]*>}i
+
+        # Extracts a video URL from HTML content
+        # @param html [String] The HTML string to parse
+        # @return [Hash] A hash with :video_url key containing the extracted URL or nil
+        def initialize(html)
+          @html = html
+        end
+
+        attr_reader :html
+
+        def url
+          return nil if html.blank?
+
+          @url ||= extract_youtube || extract_vimeo
+        end
+
+        def valid?
+          url.present?
+        end
+
+        # Returns the video thumbnail URL
+        # @return [String, nil] The thumbnail URL or nil if no video found
+        def thumbnail_url
+          return nil unless valid?
+
+          @thumbnail_url ||= if youtube?
+                               youtube_thumbnail_url
+                             elsif vimeo?
+                               vimeo_thumbnail_url
+                             end
+        end
+
+        private
+
+        def video_id
+          @video_id ||= extract_video_id
+        end
+
+        def youtube?
+          html.match?(YOUTUBE_PATTERN)
+        end
+
+        def vimeo?
+          html.match?(VIMEO_PATTERN)
+        end
+
+        def extract_video_id
+          if youtube?
+            html.match(YOUTUBE_PATTERN)&.[](1)
+          elsif vimeo?
+            html.match(VIMEO_PATTERN)&.[](1)
+          end
+        end
+
+        def extract_youtube
+          return nil unless youtube?
+
+          "https://www.youtube.com/watch?v=#{video_id}"
+        end
+
+        def extract_vimeo
+          return nil unless vimeo?
+
+          "https://vimeo.com/#{video_id}"
+        end
+
+        # Returns YouTube thumbnail URL
+        # Uses maxresdefault for best quality, falls back to hqdefault
+        def youtube_thumbnail_url
+          "https://img.youtube.com/vi/#{video_id}/maxresdefault.jpg"
+        end
+
+        # Returns Vimeo thumbnail URL using oEmbed API pattern
+        # Note: This could be enhanced to fetch actual thumbnail via HTTP request
+        def vimeo_thumbnail_url
+          # Vimeo doesn't have a predictable thumbnail URL pattern like YouTube
+          # We'd need to make an API call to get it, but for now return nil
+          # or fetch it via: https://vimeo.com/api/oembed.json?url=https://vimeo.com/{video_id}
+          nil
+        end
+      end
+    end
+  end
+end

--- a/app/services/decidim/chatbot/providers/whatsapp/envelopes/interactive_buttons.rb
+++ b/app/services/decidim/chatbot/providers/whatsapp/envelopes/interactive_buttons.rb
@@ -12,26 +12,31 @@ module Decidim
                 interactive: {
                   type: "button",
                   header: {}.tap do |header|
-                    if data[:header_text].present?
-                      header[:type] = "text"
-                      header[:text] = data[:header_text]
+                    if data[:header_video].present?
+                      header[:type] = "video"
+                      header[:video] = { link: data[:header_video] }
                     elsif data[:header_image].present?
                       header[:type] = "image"
                       header[:image] = { link: data[:header_image] }
+                    elsif data[:header_text].present?
+                      header[:type] = "text"
+                      header[:text] = data[:header_text]
                     end
                   end,
                   body: {
                     text: data[:body_text]
                   },
-                  footer: { text: data[:footer_text] },
+                  footer: {}.tap do |footer|
+                    footer[:text] = data[:footer_text]
+                  end,
                   action: {
                     buttons: data[:buttons].map do |button|
                       { type: "reply", reply: { id: button[:id], title: button[:title] } }
                     end
                   }
                 }.tap do |interactive|
-                  interactive.delete(:header) if data[:header_text].blank? && data[:header_image].blank?
-                  interactive.delete(:footer) if data[:footer_text].blank?
+                  interactive.delete(:header) if interactive[:header].blank?
+                  interactive.delete(:footer) if interactive[:footer].blank?
                 end
               )
             end

--- a/app/services/decidim/chatbot/providers/whatsapp/envelopes/interactive_buttons.rb
+++ b/app/services/decidim/chatbot/providers/whatsapp/envelopes/interactive_buttons.rb
@@ -26,9 +26,9 @@ module Decidim
                   body: {
                     text: data[:body_text]
                   },
-                  footer: {}.tap do |footer|
-                    footer[:text] = data[:footer_text]
-                  end,
+                  footer: {
+                    text: data[:footer_text]
+                  },
                   action: {
                     buttons: data[:buttons].map do |button|
                       { type: "reply", reply: { id: button[:id], title: button[:title] } }

--- a/app/services/decidim/chatbot/providers/whatsapp/envelopes/interactive_buttons.rb
+++ b/app/services/decidim/chatbot/providers/whatsapp/envelopes/interactive_buttons.rb
@@ -36,7 +36,7 @@ module Decidim
                   }
                 }.tap do |interactive|
                   interactive.delete(:header) if interactive[:header].blank?
-                  interactive.delete(:footer) if interactive[:footer].blank?
+                  interactive.delete(:footer) if data[:footer_text].blank?
                 end
               )
             end

--- a/app/services/decidim/chatbot/workflows/proposals_workflow.rb
+++ b/app/services/decidim/chatbot/workflows/proposals_workflow.rb
@@ -88,7 +88,7 @@ module Decidim
           total_limit = 1024
 
           # Calculate fixed overhead
-          title_overhead = sanitize_text(proposal.title, 100).length + 6 # "*title*\n\n"
+          title_overhead = sanitize_text(proposal.title, 100).length + 4 # "*title*\n\n"
           video_overhead = video.valid? ? video.url.length + 4 : 0 # "🎥 url\n\n"
           proposal_url_overhead = resource_url(proposal).length + 2 # "\n\nurl"
 

--- a/app/services/decidim/chatbot/workflows/proposals_workflow.rb
+++ b/app/services/decidim/chatbot/workflows/proposals_workflow.rb
@@ -59,7 +59,7 @@ module Decidim
           # Pre-calculate title and URL to avoid redundant method calls
           title_text = sanitize_text(proposal.title, 100)
           proposal_url = resource_url(proposal)
-          
+
           # Calculate available space for body text and sanitize accordingly
           body_text = sanitize_text(proposal.body, calculate_max_body_length(video, title_text, proposal_url))
 
@@ -68,8 +68,8 @@ module Decidim
           body += "🎥 #{video.url}\n\n" if video.valid?
           body += "#{body_text}\n\n#{proposal_url}"
 
-          # Use video thumbnail as header image if available, otherwise use proposal photo
-          header_image = video.thumbnail_url.presence || resource_url(proposal.photo)
+          # Use video thumbnail as header image if available, otherwise use proposal photo with fallback
+          header_image = video.thumbnail_url.presence || resource_url(proposal.photo, fallback_image: true)
 
           send_message!(
             type: :interactive_buttons,

--- a/app/services/decidim/chatbot/workflows/proposals_workflow.rb
+++ b/app/services/decidim/chatbot/workflows/proposals_workflow.rb
@@ -39,11 +39,12 @@ module Decidim
             type: :interactive_carousel,
             body_text: body,
             cards: current_proposals.map do |proposal|
+              video = Decidim::Chatbot::Media::VideoEmbedExtractor.new(translated_attribute(proposal.body))
               {
                 id: proposal.id,
                 title: I18n.t("decidim.chatbot.workflows.proposals.buttons.view_proposal"),
                 body_text: sanitize_text(proposal.title, 60).presence || I18n.t("decidim.chatbot.workflows.proposals.buttons.view_proposal"),
-                image_url: resource_url(proposal.photo, fallback_image: true)
+                image_url: video.thumbnail_url.presence || resource_url(proposal.photo, fallback_image: true)
               }
             end
           )
@@ -52,11 +53,25 @@ module Decidim
         def send_proposal_details
           return process_unprocessable_input unless proposal
 
-          body = "*#{sanitize_text(proposal.title, 100)}*\n\n#{sanitize_text(proposal.body, 800)}\n\n#{resource_url(proposal)}"
+          # Check if proposal body contains a video iframe
+          video = Decidim::Chatbot::Media::VideoEmbedExtractor.new(translated_attribute(proposal.body))
+
+          # Build body text with video URL if present
+          title_text = sanitize_text(proposal.title, 100)
+          body_text = sanitize_text(proposal.body, calculate_max_body_length(video))
+          proposal_url = resource_url(proposal)
+
+          body = "*#{title_text}*\n\n"
+          body += "🎥 #{video.url}\n\n" if video.valid?
+          body += "#{body_text}\n\n#{proposal_url}"
+
+          # Use video thumbnail as header image if available, otherwise use proposal photo
+          header_image = video.thumbnail_url.presence || resource_url(proposal.photo)
+
           send_message!(
             type: :interactive_buttons,
             body_text: body,
-            header_image: resource_url(proposal.photo),
+            header_image:,
             footer_text: sanitize_text(proposal.creator_author&.presenter&.name, 60),
             buttons: [
               {
@@ -65,6 +80,23 @@ module Decidim
               }
             ]
           )
+        end
+
+        # Calculate maximum body length dynamically to stay within 1024 char limit
+        def calculate_max_body_length(video)
+          # WhatsApp body text limit is 1024 characters
+          total_limit = 1024
+
+          # Calculate fixed overhead
+          title_overhead = sanitize_text(proposal.title, 100).length + 6 # "*title*\n\n"
+          video_overhead = video.valid? ? video.url.length + 6 : 0 # "🎥 url\n\n" (emoji is 2 bytes)
+          proposal_url_overhead = resource_url(proposal).length + 2 # "\n\nurl"
+
+          # Reserve space for newlines and formatting
+          reserved_space = title_overhead + video_overhead + proposal_url_overhead
+
+          # Return available space for body text, with minimum of 100 chars
+          [total_limit - reserved_space, 100].max
         end
 
         def send_continuation

--- a/app/services/decidim/chatbot/workflows/proposals_workflow.rb
+++ b/app/services/decidim/chatbot/workflows/proposals_workflow.rb
@@ -89,7 +89,7 @@ module Decidim
 
           # Calculate fixed overhead
           title_overhead = sanitize_text(proposal.title, 100).length + 6 # "*title*\n\n"
-          video_overhead = video.valid? ? video.url.length + 6 : 0 # "🎥 url\n\n" (emoji is 2 bytes)
+          video_overhead = video.valid? ? video.url.length + 4 : 0 # "🎥 url\n\n"
           proposal_url_overhead = resource_url(proposal).length + 2 # "\n\nurl"
 
           # Reserve space for newlines and formatting

--- a/app/services/decidim/chatbot/workflows/proposals_workflow.rb
+++ b/app/services/decidim/chatbot/workflows/proposals_workflow.rb
@@ -56,11 +56,14 @@ module Decidim
           # Check if proposal body contains a video iframe
           video = Decidim::Chatbot::Media::VideoEmbedExtractor.new(translated_attribute(proposal.body))
 
-          # Build body text with video URL if present
+          # Pre-calculate title and URL to avoid redundant method calls
           title_text = sanitize_text(proposal.title, 100)
-          body_text = sanitize_text(proposal.body, calculate_max_body_length(video))
           proposal_url = resource_url(proposal)
+          
+          # Calculate available space for body text and sanitize accordingly
+          body_text = sanitize_text(proposal.body, calculate_max_body_length(video, title_text, proposal_url))
 
+          # Build body text with video URL if present
           body = "*#{title_text}*\n\n"
           body += "🎥 #{video.url}\n\n" if video.valid?
           body += "#{body_text}\n\n#{proposal_url}"
@@ -83,14 +86,18 @@ module Decidim
         end
 
         # Calculate maximum body length dynamically to stay within 1024 char limit
-        def calculate_max_body_length(video)
+        # @param video [VideoEmbedExtractor] The video extractor instance
+        # @param title_text [String] The sanitized title text
+        # @param proposal_url [String] The proposal URL
+        # @return [Integer] Maximum allowed length for body text
+        def calculate_max_body_length(video, title_text, proposal_url)
           # WhatsApp body text limit is 1024 characters
           total_limit = 1024
 
-          # Calculate fixed overhead
-          title_overhead = sanitize_text(proposal.title, 100).length + 4 # "*title*\n\n"
+          # Calculate fixed overhead using pre-calculated values
+          title_overhead = title_text.length + 4 # "*title*\n\n"
           video_overhead = video.valid? ? video.url.length + 4 : 0 # "🎥 url\n\n"
-          proposal_url_overhead = resource_url(proposal).length + 2 # "\n\nurl"
+          proposal_url_overhead = proposal_url.length + 2 # "\n\nurl"
 
           # Reserve space for newlines and formatting
           reserved_space = title_overhead + video_overhead + proposal_url_overhead

--- a/spec/services/media/video_embed_extractor_spec.rb
+++ b/spec/services/media/video_embed_extractor_spec.rb
@@ -1,0 +1,218 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  module Chatbot
+    module Media
+      describe VideoEmbedExtractor do
+        describe "#url, #valid?, #thumbnail_url" do
+          context "when html is blank" do
+            it "returns nil url and is not valid" do
+              expect(described_class.new(nil).url).to be_nil
+              expect(described_class.new(nil).valid?).to be false
+              expect(described_class.new(nil).thumbnail_url).to be_nil
+
+              expect(described_class.new("").url).to be_nil
+              expect(described_class.new("").valid?).to be false
+              expect(described_class.new("").thumbnail_url).to be_nil
+
+              expect(described_class.new("   ").url).to be_nil
+              expect(described_class.new("   ").valid?).to be false
+              expect(described_class.new("   ").thumbnail_url).to be_nil
+            end
+          end
+
+          context "when html has no video iframe" do
+            let(:html) do
+              <<-HTML
+                <p>This is a proposal with no video</p>
+                <div>Some content here</div>
+              HTML
+            end
+
+            it "returns nil url and is not valid" do
+              extractor = described_class.new(html)
+              expect(extractor.url).to be_nil
+              expect(extractor.valid?).to be false
+              expect(extractor.thumbnail_url).to be_nil
+            end
+          end
+
+          context "when html contains a YouTube iframe" do
+            context "with standard embed format" do
+              let(:html) do
+                <<-HTML
+                  <p>Check out this video:</p>
+                  <iframe width="560" height="315" src="https://www.youtube.com/embed/dQw4w9WgXcQ" frameborder="0" allowfullscreen></iframe>
+                  <p>Great video!</p>
+                HTML
+              end
+
+              it "extracts and normalizes the YouTube URL" do
+                extractor = described_class.new(html)
+                expect(extractor.url).to eq("https://www.youtube.com/watch?v=dQw4w9WgXcQ")
+                expect(extractor.valid?).to be true
+              end
+
+              it "extracts the YouTube thumbnail URL" do
+                extractor = described_class.new(html)
+                expect(extractor.thumbnail_url).to eq("https://img.youtube.com/vi/dQw4w9WgXcQ/maxresdefault.jpg")
+              end
+            end
+
+            context "with embed URL containing query parameters" do
+              let(:html) do
+                '<iframe src="https://www.youtube.com/embed/dQw4w9WgXcQ?autoplay=1&controls=0"></iframe>'
+              end
+
+              it "extracts the video ID and normalizes to watch URL" do
+                extractor = described_class.new(html)
+                expect(extractor.url).to eq("https://www.youtube.com/watch?v=dQw4w9WgXcQ")
+                expect(extractor.valid?).to be true
+              end
+
+              it "extracts the thumbnail URL" do
+                extractor = described_class.new(html)
+                expect(extractor.thumbnail_url).to eq("https://img.youtube.com/vi/dQw4w9WgXcQ/maxresdefault.jpg")
+              end
+            end
+
+            context "with youtu.be short URL" do
+              let(:html) do
+                '<iframe src="https://youtu.be/dQw4w9WgXcQ"></iframe>'
+              end
+
+              it "extracts and normalizes the YouTube URL" do
+                extractor = described_class.new(html)
+                expect(extractor.url).to eq("https://www.youtube.com/watch?v=dQw4w9WgXcQ")
+                expect(extractor.valid?).to be true
+              end
+
+              it "extracts the thumbnail URL" do
+                extractor = described_class.new(html)
+                expect(extractor.thumbnail_url).to eq("https://img.youtube.com/vi/dQw4w9WgXcQ/maxresdefault.jpg")
+              end
+            end
+
+            context "with single quotes in src attribute" do
+              let(:html) do
+                "<iframe src='https://www.youtube.com/embed/dQw4w9WgXcQ'></iframe>"
+              end
+
+              it "extracts the YouTube URL" do
+                extractor = described_class.new(html)
+                expect(extractor.url).to eq("https://www.youtube.com/watch?v=dQw4w9WgXcQ")
+                expect(extractor.valid?).to be true
+              end
+
+              it "extracts the thumbnail URL" do
+                extractor = described_class.new(html)
+                expect(extractor.thumbnail_url).to eq("https://img.youtube.com/vi/dQw4w9WgXcQ/maxresdefault.jpg")
+              end
+            end
+          end
+
+          context "when html contains a Vimeo iframe" do
+            context "with standard embed format" do
+              let(:html) do
+                <<-HTML
+                  <p>Check out this Vimeo video:</p>
+                  <iframe src="https://player.vimeo.com/video/123456789" width="640" height="360" frameborder="0" allowfullscreen></iframe>
+                  <p>Amazing content!</p>
+                HTML
+              end
+
+              it "extracts and normalizes the Vimeo URL" do
+                extractor = described_class.new(html)
+                expect(extractor.url).to eq("https://vimeo.com/123456789")
+                expect(extractor.valid?).to be true
+              end
+
+              it "returns nil for thumbnail_url (Vimeo requires API call)" do
+                extractor = described_class.new(html)
+                expect(extractor.thumbnail_url).to be_nil
+              end
+            end
+
+            context "with embed URL containing query parameters" do
+              let(:html) do
+                '<iframe src="https://player.vimeo.com/video/123456789?autoplay=1&title=0"></iframe>'
+              end
+
+              it "extracts the video ID and normalizes to vimeo.com URL" do
+                extractor = described_class.new(html)
+                expect(extractor.url).to eq("https://vimeo.com/123456789")
+                expect(extractor.valid?).to be true
+              end
+            end
+
+            context "with www subdomain" do
+              let(:html) do
+                '<iframe src="https://www.player.vimeo.com/video/987654321"></iframe>'
+              end
+
+              it "extracts the Vimeo URL" do
+                extractor = described_class.new(html)
+                expect(extractor.url).to eq("https://vimeo.com/987654321")
+                expect(extractor.valid?).to be true
+              end
+            end
+          end
+
+          context "when html contains multiple video iframes" do
+            let(:html) do
+              <<-HTML
+                <p>Check out these videos:</p>
+                <iframe src="https://www.youtube.com/embed/dQw4w9WgXcQ"></iframe>
+                <iframe src="https://player.vimeo.com/video/123456789"></iframe>
+              HTML
+            end
+
+            it "returns the first video found (YouTube)" do
+              extractor = described_class.new(html)
+              expect(extractor.url).to eq("https://www.youtube.com/watch?v=dQw4w9WgXcQ")
+              expect(extractor.valid?).to be true
+              expect(extractor.thumbnail_url).to eq("https://img.youtube.com/vi/dQw4w9WgXcQ/maxresdefault.jpg")
+            end
+          end
+
+          context "when html contains mixed content with iframe" do
+            let(:html) do
+              <<-HTML
+                <h2>My Proposal Title</h2>
+                <p>This is my proposal description with <strong>bold text</strong> and <em>italic text</em>.</p>
+                <ul>
+                  <li>Point one</li>
+                  <li>Point two</li>
+                </ul>
+                <iframe width="560" height="315" src="https://www.youtube.com/embed/test123" frameborder="0"></iframe>
+                <p>More text after the video.</p>
+              HTML
+            end
+
+            it "correctly extracts the video URL from mixed content" do
+              extractor = described_class.new(html)
+              expect(extractor.url).to eq("https://www.youtube.com/watch?v=test123")
+              expect(extractor.valid?).to be true
+              expect(extractor.thumbnail_url).to eq("https://img.youtube.com/vi/test123/maxresdefault.jpg")
+            end
+          end
+
+          context "when iframe is not a video iframe" do
+            let(:html) do
+              '<iframe src="https://www.example.com/some-content"></iframe>'
+            end
+
+            it "returns nil url and is not valid" do
+              extractor = described_class.new(html)
+              expect(extractor.url).to be_nil
+              expect(extractor.valid?).to be false
+              expect(extractor.thumbnail_url).to be_nil
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/services/media/video_embed_extractor_spec.rb
+++ b/spec/services/media/video_embed_extractor_spec.rb
@@ -57,7 +57,7 @@ module Decidim
 
               it "extracts the YouTube thumbnail URL" do
                 extractor = described_class.new(html)
-                expect(extractor.thumbnail_url).to eq("https://img.youtube.com/vi/dQw4w9WgXcQ/maxresdefault.jpg")
+                expect(extractor.thumbnail_url).to eq("https://img.youtube.com/vi/dQw4w9WgXcQ/hqdefault.jpg")
               end
             end
 
@@ -74,7 +74,7 @@ module Decidim
 
               it "extracts the thumbnail URL" do
                 extractor = described_class.new(html)
-                expect(extractor.thumbnail_url).to eq("https://img.youtube.com/vi/dQw4w9WgXcQ/maxresdefault.jpg")
+                expect(extractor.thumbnail_url).to eq("https://img.youtube.com/vi/dQw4w9WgXcQ/hqdefault.jpg")
               end
             end
 
@@ -91,7 +91,7 @@ module Decidim
 
               it "extracts the thumbnail URL" do
                 extractor = described_class.new(html)
-                expect(extractor.thumbnail_url).to eq("https://img.youtube.com/vi/dQw4w9WgXcQ/maxresdefault.jpg")
+                expect(extractor.thumbnail_url).to eq("https://img.youtube.com/vi/dQw4w9WgXcQ/hqdefault.jpg")
               end
             end
 
@@ -108,7 +108,7 @@ module Decidim
 
               it "extracts the thumbnail URL" do
                 extractor = described_class.new(html)
-                expect(extractor.thumbnail_url).to eq("https://img.youtube.com/vi/dQw4w9WgXcQ/maxresdefault.jpg")
+                expect(extractor.thumbnail_url).to eq("https://img.youtube.com/vi/dQw4w9WgXcQ/hqdefault.jpg")
               end
             end
 
@@ -125,7 +125,7 @@ module Decidim
 
               it "extracts the thumbnail URL" do
                 extractor = described_class.new(html)
-                expect(extractor.thumbnail_url).to eq("https://img.youtube.com/vi/dQw4w9WgXcQ/maxresdefault.jpg")
+                expect(extractor.thumbnail_url).to eq("https://img.youtube.com/vi/dQw4w9WgXcQ/hqdefault.jpg")
               end
             end
           end
@@ -190,7 +190,7 @@ module Decidim
               extractor = described_class.new(html)
               expect(extractor.url).to eq("https://www.youtube.com/watch?v=dQw4w9WgXcQ")
               expect(extractor.valid?).to be true
-              expect(extractor.thumbnail_url).to eq("https://img.youtube.com/vi/dQw4w9WgXcQ/maxresdefault.jpg")
+              expect(extractor.thumbnail_url).to eq("https://img.youtube.com/vi/dQw4w9WgXcQ/hqdefault.jpg")
             end
           end
 
@@ -212,7 +212,7 @@ module Decidim
               extractor = described_class.new(html)
               expect(extractor.url).to eq("https://www.youtube.com/watch?v=test123")
               expect(extractor.valid?).to be true
-              expect(extractor.thumbnail_url).to eq("https://img.youtube.com/vi/test123/maxresdefault.jpg")
+              expect(extractor.thumbnail_url).to eq("https://img.youtube.com/vi/test123/hqdefault.jpg")
             end
           end
 

--- a/spec/services/media/video_embed_extractor_spec.rb
+++ b/spec/services/media/video_embed_extractor_spec.rb
@@ -111,6 +111,23 @@ module Decidim
                 expect(extractor.thumbnail_url).to eq("https://img.youtube.com/vi/dQw4w9WgXcQ/maxresdefault.jpg")
               end
             end
+
+            context "with a youtube-nocookie.com embed URL" do
+              let(:html) do
+                '<iframe src="https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ?autoplay=1"></iframe>'
+              end
+
+              it "extracts and normalizes the YouTube URL" do
+                extractor = described_class.new(html)
+                expect(extractor.url).to eq("https://www.youtube.com/watch?v=dQw4w9WgXcQ")
+                expect(extractor.valid?).to be true
+              end
+
+              it "extracts the thumbnail URL" do
+                extractor = described_class.new(html)
+                expect(extractor.thumbnail_url).to eq("https://img.youtube.com/vi/dQw4w9WgXcQ/maxresdefault.jpg")
+              end
+            end
           end
 
           context "when html contains a Vimeo iframe" do

--- a/spec/services/workflows/proposals_workflow_spec.rb
+++ b/spec/services/workflows/proposals_workflow_spec.rb
@@ -340,7 +340,7 @@ module Decidim
                 expect(adapter).to receive(:send_message!).with(
                   hash_including(
                     type: :interactive_buttons,
-                    header_image: "https://img.youtube.com/vi/dQw4w9WgXcQ/maxresdefault.jpg"
+                    header_image: "https://img.youtube.com/vi/dQw4w9WgXcQ/hqdefault.jpg"
                   )
                 )
                 subject.start

--- a/spec/services/workflows/proposals_workflow_spec.rb
+++ b/spec/services/workflows/proposals_workflow_spec.rb
@@ -307,6 +307,136 @@ module Decidim
               )
               subject.start
             end
+
+            context "when proposal body contains a YouTube iframe" do
+              let(:body_with_youtube) do
+                {
+                  en: <<-HTML
+                    <h2>My Proposal</h2>
+                    <p>Check out this video:</p>
+                    <iframe src="https://www.youtube.com/embed/dQw4w9WgXcQ" width="560" height="315"></iframe>
+                    <p>More details about the proposal.</p>
+                  HTML
+                }
+              end
+
+              before do
+                clicked_proposal.update!(body: body_with_youtube)
+              end
+
+              it "sends interactive_buttons message with video URL in body text" do
+                expect(adapter).to receive(:send_message!).with(
+                  hash_including(
+                    type: :interactive_buttons,
+                    buttons: [hash_including(id: "comment-#{clicked_proposal.id}")]
+                  )
+                ) do |args|
+                  expect(args[:body_text]).to include("🎥 https://www.youtube.com/watch?v=dQw4w9WgXcQ")
+                end
+                subject.start
+              end
+
+              it "uses video thumbnail as header_image" do
+                expect(adapter).to receive(:send_message!).with(
+                  hash_including(
+                    type: :interactive_buttons,
+                    header_image: "https://img.youtube.com/vi/dQw4w9WgXcQ/maxresdefault.jpg"
+                  )
+                )
+                subject.start
+              end
+
+              it "respects the 1024 character body limit" do
+                expect(adapter).to receive(:send_message!) do |args|
+                  expect(args[:body_text].length).to be <= 1024
+                end
+                subject.start
+              end
+            end
+
+            context "when proposal body contains a Vimeo iframe" do
+              let(:body_with_vimeo) do
+                {
+                  en: <<-HTML
+                    <h2>My Proposal</h2>
+                    <p>Check out this Vimeo video:</p>
+                    <iframe src="https://player.vimeo.com/video/123456789" width="640" height="360"></iframe>
+                    <p>More details.</p>
+                  HTML
+                }
+              end
+
+              before do
+                clicked_proposal.update!(body: body_with_vimeo)
+              end
+
+              it "sends interactive_buttons message with video URL in body text" do
+                expect(adapter).to receive(:send_message!).with(
+                  hash_including(
+                    type: :interactive_buttons,
+                    buttons: [hash_including(id: "comment-#{clicked_proposal.id}")]
+                  )
+                ) do |args|
+                  expect(args[:body_text]).to include("🎥 https://vimeo.com/123456789")
+                end
+                subject.start
+              end
+
+              it "falls back to proposal photo for header_image (Vimeo has no thumbnail)" do
+                expect(adapter).to receive(:send_message!) do |args|
+                  expect(args[:header_image]).to be_present
+                  expect(args[:header_image]).not_to include("vimeo")
+                end
+                subject.start
+              end
+            end
+
+            context "when proposal body contains no video iframe" do
+              let(:body_without_video) do
+                {
+                  en: <<-HTML
+                    <h2>My Proposal</h2>
+                    <p>This is a text-only proposal with no video.</p>
+                    <ul>
+                      <li>Point one</li>
+                      <li>Point two</li>
+                    </ul>
+                  HTML
+                }
+              end
+
+              before do
+                clicked_proposal.update!(body: body_without_video)
+              end
+
+              it "sends interactive_buttons message without video URL" do
+                expect(adapter).to receive(:send_message!).with(
+                  hash_including(
+                    type: :interactive_buttons,
+                    buttons: [hash_including(id: "comment-#{clicked_proposal.id}")]
+                  )
+                ) do |args|
+                  expect(args[:body_text]).not_to include("🎥")
+                  expect(args[:body_text]).not_to include("youtube.com")
+                  expect(args[:body_text]).not_to include("vimeo.com")
+                end
+                subject.start
+              end
+
+              it "uses proposal photo for header_image" do
+                expect(adapter).to receive(:send_message!) do |args|
+                  expect(args[:header_image]).to be_present
+                end
+                subject.start
+              end
+
+              it "respects the 1024 character body limit" do
+                expect(adapter).to receive(:send_message!) do |args|
+                  expect(args[:body_text].length).to be <= 1024
+                end
+                subject.start
+              end
+            end
           end
 
           context "when a comment button is clicked" do


### PR DESCRIPTION
## Summary

This PR implements issue #16 - Use embedded video iframes in proposal details (WhatsApp interactive reply).

## Changes

### 1. Video URL & Thumbnail Extraction
- Created `VideoEmbedExtractor` service class to parse iframe URLs from proposal bodies
- Supports YouTube and Vimeo video embeds
- Extracts video watch URLs and thumbnail images
- YouTube thumbnails use the public image CDN (no API required)
- Vimeo thumbnail extraction noted for future enhancement (requires API call)

### 2. Updated ProposalsWorkflow
- Detects video iframes in proposal bodies
- Displays video URL as clickable link with 🎥 emoji in message body
- Uses video thumbnail as header image (when available)
- Falls back to proposal photo if no thumbnail available
- **Dynamic body length calculation** to ensure messages stay within WhatsApp's 1024 character limit

### 3. Comprehensive Tests
- Unit tests for `VideoEmbedExtractor` covering YouTube, Vimeo, and edge cases
- Workflow tests for proposals with/without video iframes
- Tests verify thumbnail URLs and body text formatting
- Tests confirm 1024 character limit is respected

## Technical Notes

- Video URLs are displayed as clickable links in the message body (WhatsApp will auto-link them)
- Cannot send YouTube/Vimeo URLs directly as video headers (WhatsApp requires `.mp4`/`.3gpp` files)
- Thumbnail extraction is legal and uses public APIs
- Body length calculation accounts for title, video URL, and proposal URL lengths

## Testing

All tests pass and cover:
- ✅ YouTube iframe extraction and thumbnail URLs
- ✅ Vimeo iframe extraction (thumbnail fallback)
- ✅ Multiple video formats (standard embed, short URLs, with query params)
- ✅ Proposals without videos maintain existing behavior
- ✅ 1024 character body limit enforcement

Closes #16

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Proposals now detect embedded YouTube/Vimeo videos and show video URLs and thumbnails in carousel cards and details; body text is dynamically truncated to fit limits.
  * WhatsApp messages now allow video headers (falling back to image or text) and use a standardized footer text format.

* **Tests**
  * Added comprehensive tests for video extraction and message formatting covering YouTube, Vimeo, and mixed content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->